### PR TITLE
Update LibreHardwareMonitor to 0.9.5 // Update to .NET10

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup .NET 9.x
+      - name: Setup .NET 10.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@ obj/
 *.sln.docstates
 
 # Visual Studio Code
-.vscode/
+.vscode/*
+.vscode/settings.json
+.vscode/*.code-workspace
+!.vscode/tasks.json
+!.vscode/launch.json
 
 # Rider
 .idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gamesense-sdk"]
+	path = gamesense-sdk
+	url = https://github.com/SteelSeries/gamesense-sdk.git

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch CmpInf (Debug Single File)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "Publish (Debug Single File)",
+      "program": "${workspaceFolder}/bin/Debug/net9.0-windows/win-x64/publish/CmpInf.exe",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Launch installed AppData copy",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${env:APPDATA}/CmpInf_SteelSeriesOledPcInfo/CmpInf_SteelSeriesOledPcInfo.exe",
+      "args": [],
+      "cwd": "${env:APPDATA}/CmpInf_SteelSeriesOledPcInfo",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,7 @@
         "/p:IncludeAllContentForSelfExtract=true",
         "/p:PublishTrimmed=false",
         "--output",
-        "bin/Debug/net9.0-windows/win-x64/publish"
+        "bin/Debug/net10.0-windows/win-x64/publish"
       ],
       "problemMatcher": ["$msCompile"],
       "group": "none",
@@ -70,7 +70,7 @@
         "/p:IncludeAllContentForSelfExtract=true",
         "/p:PublishTrimmed=false",
         "--output",
-        "bin/Release/net9.0-windows/win-x64/publish"
+        "bin/Release/net10.0-windows/win-x64/publish"
       ],
       "problemMatcher": ["$msCompile"],
       "group": "none",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,80 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Restore dependencies",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "restore",
+        "CmpInf.csproj"
+      ],
+      "problemMatcher": ["$msCompile"],
+      "group": "none"
+    },
+    {
+      "label": "Build (Debug)",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "CmpInf.csproj",
+        "-c",
+        "Debug"
+      ],
+      "problemMatcher": ["$msCompile"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Publish (Debug Single File)",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "publish",
+        "CmpInf.csproj",
+        "-c",
+        "Debug",
+        "-r",
+        "win-x64",
+        "--self-contained",
+        "true",
+        "/p:PublishSingleFile=true",
+        "/p:IncludeNativeLibrariesForSelfExtract=true",
+        "/p:IncludeAllContentForSelfExtract=true",
+        "/p:PublishTrimmed=false",
+        "--output",
+        "bin/Debug/net9.0-windows/win-x64/publish"
+      ],
+      "problemMatcher": ["$msCompile"],
+      "group": "none",
+      "dependsOn": "Restore dependencies"
+    },
+    {
+      "label": "Publish (Release Single File)",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "publish",
+        "CmpInf.csproj",
+        "-c",
+        "Release",
+        "-r",
+        "win-x64",
+        "--self-contained",
+        "true",
+        "/p:PublishSingleFile=true",
+        "/p:IncludeNativeLibrariesForSelfExtract=true",
+        "/p:IncludeAllContentForSelfExtract=true",
+        "/p:PublishTrimmed=false",
+        "--output",
+        "bin/Release/net9.0-windows/win-x64/publish"
+      ],
+      "problemMatcher": ["$msCompile"],
+      "group": "none",
+      "dependsOn": "Restore dependencies"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+AGENTS.md
+
+This project replaces the removed SteelSeries System Monitor App. It uses the LibreHardwareMonitorLib to gather system information and display them on various SteelSeries OLED displays like Keyboards or Headphone stations.
+
+## Runtime environment (for AI agents)
+
+- Primary dev OS: Windows 11.
+- Default shell: PowerShell 7.
+
+## Expectations
+- Keep changes small and consistent with the existing architecture.
+- Update `docs/` and relevant `README.md` files whenever you change behaviour or add features.
+- Update CI workflow after relevant changes
+
+## DOs
+- ALWAYS make sure to stick with security best practises
+- This software runs on gamer computers. ALWAYS consider application performance as a top priority, to not have influence on running games. 
+
+## DONTs
+- NEVER touch files in `gamesense-sdk/`. We only add it as a submodule for documentation reference. 
+
+## Knowledgebase
+- `README.md` for general information about this application
+- `gamesense-sdk/` for all information regarding 

--- a/CmpInf.csproj
+++ b/CmpInf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/CmpInf.csproj
+++ b/CmpInf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/HardwareAccessMode.cs
+++ b/HardwareAccessMode.cs
@@ -1,0 +1,6 @@
+﻿public enum HardwareAccessMode
+{
+    Full,
+    SafeUserMode
+}
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ As for now this project _(out of this README)_ is **fully** generated with GitHu
 CmpInf uses LibreHardwareMonitorLib v0.9.5, which bundles PawnIO as the successor to the WinRing0 driver. PawnIO is the signed kernel component that LibreHardwareMonitor uses as additional sensor information source. 
 
 ### PawnIO requirement
-PawnIO is required for some motherboard or CPU sensors that LibreHardwareMonitorLib alone does not expose. Without PawnIO, CmpInf falls back to its **SafeUserMode (no-kernel)** operating profile, which keeps GPU, storage, and network sensors running while omitting kernel-only sources such as motherboard and CPU controllers. Be aware that PawnIO can influence cheat detection software like FaceIT: https://github.com/namazso/PawnIO.Setup/issues/1
+PawnIO is required for some motherboard or CPU sensors that LibreHardwareMonitorLib alone does not expose. Without PawnIO, CmpInf falls back to its **SafeUserMode (no-kernel)** operating profile, which keeps GPU, storage, and network sensors running while omitting kernel-only sources such as motherboard and CPU controllers.  
+**Be aware that PawnIO can influence cheat detection software like FaceIT: [namazso/PawnIO.Setup #1](https://github.com/namazso/PawnIO.Setup/issues/1)**
 
 
 ## How to use
@@ -89,12 +90,14 @@ No more issues are known so far, if you find one, feel free to raise an issue!
   
 
 ### Credits
-- [LibreHardwareMonitorLib](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) for sensor data <3  
+- [LibreHardwareMonitorLib](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) for sensor data <3
+- [PawnIO](https://github.com/namazso/PawnIO) for even more sensor data <3
 - [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) for easy JSON handling <3  
 - [SteelSeries GameSense SDK](https://github.com/SteelSeries/gamesense-sdk) for easy API usage <3  
 
 ### Screenshots  
 
 ![IMG_7906](https://github.com/user-attachments/assets/dd5928d4-c02d-425e-8f2f-b44a1f9fe047)
-![image](https://github.com/user-attachments/assets/d86b7ce4-732f-4fcd-aed3-c7242c3ec867)  
-![image](https://github.com/user-attachments/assets/f2978d14-ab04-45c2-81b4-ece9565551ba)  
+<img width="499" height="176" alt="image" src="https://github.com/user-attachments/assets/4974645d-2834-4d1e-8467-0f1fafe72a6e" />  
+<img width="498" height="330" alt="image" src="https://github.com/user-attachments/assets/97cac6d2-e95e-4f23-bdd0-4bcc3c93181b" />
+  

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ As for now this project _(out of this README)_ is **fully** generated with GitHu
 ## How to install  
 
 ### What do you need?  
+- [.NET 10](https://dotnet.microsoft.com/en-us/download/dotnet/10.0/runtime)
 - [SteelSeries GG](https://steelseries.com/gg) installed and running (consider to put it into autostart)
 - [Download](https://github.com/TBSniller/cmpinf/releases/latest) the latest release of CmpInf and run it
 - [PawnIO](https://pawnio.eu/) optional for CPU and motherboard sensors

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ CmpInf is an application designed to work with the SteelSeries GameSense GG soft
   
 ### Why?  
 I noticed that one of the reasons I originally bought the keyboard has been removed. According to SteelSeries, they are addressing a security issue related to how the original System Monitor gathered system information.  
-In our case, we use LibreHardwareMonitorLib, which — as far as I know — relies on the same (still unpatched) Ring0 driver. However, I believe the attack surface in this application is much smaller than with the System Monitor that ships with GG, since we do not run as admin by default and do not expose any interfaces to the outside.   
-**Netherless be warned and try to avoid running this tool as administrator.** 
+We now depend on LibreHardwareMonitorLib v0.9.5, which ships the PawnIO kernel driver instead of the legacy WinRing0 component, so the vulnerability that SteelSeries has been patching no longer applies to this replacement. PawnIO is extra software and only needs to be installed if there is a need for CPU or motherboard sensors. 
 
 
 https://github.com/user-attachments/assets/8693f539-4208-47f7-9fca-ced591f6035d  
@@ -24,13 +23,21 @@ https://github.com/user-attachments/assets/8693f539-4208-47f7-9fca-ced591f6035d
 - Autostart support
    
 ### How?
-As for now this project _(out of this README)_ is **fully** generated with GitHub CoPilot, so please take it with a grain of salt and feel free to raise an issue or PR to make it a bit better.  
+As for now this project _(out of this README)_ is **fully** generated with GitHub CoPilot/Codex, so please take it with a grain of salt and feel free to raise an issue or PR to make it a bit better.  
 
 ## How to install  
 
 ### What do you need?  
 - [SteelSeries GG](https://steelseries.com/gg) installed and running (consider to put it into autostart)
 - [Download](https://github.com/TBSniller/cmpinf/releases/latest) the latest release of CmpInf and run it
+- [PawnIO](https://pawnio.eu/) optional for CPU and motherboard sensors
+
+### LibreHardwareMonitor driver
+CmpInf uses LibreHardwareMonitorLib v0.9.5, which bundles PawnIO as the successor to the WinRing0 driver. PawnIO is the signed kernel component that LibreHardwareMonitor uses as additional sensor information source. 
+
+### PawnIO requirement
+PawnIO is required for some motherboard or CPU sensors that LibreHardwareMonitorLib alone does not expose. Without PawnIO, CmpInf falls back to its **SafeUserMode (no-kernel)** operating profile, which keeps GPU, storage, and network sensors running while omitting kernel-only sources such as motherboard and CPU controllers. Be aware that PawnIO can influence cheat detection software like FaceIT: https://github.com/namazso/PawnIO.Setup/issues/1
+
 
 ## How to use
 ### First start  

--- a/StatusForm.cs
+++ b/StatusForm.cs
@@ -1,13 +1,19 @@
 using System;
-using System.Windows.Forms;
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 public class StatusForm : Form
 {
     private readonly ListBox logListBox;
     private readonly CheckBox debugCheckBox;
+    private readonly Label pawnIoStatusLabel;
+    private readonly LinkLabel pawnIoStateLinkLabel;
+    private readonly Button openPawnIoInstallerButton;
+    private readonly Button openRepoButton;
     private static StatusForm? instance;
+    private const string PawnIoIssueUrl = "https://github.com/namazso/PawnIO.Setup/issues/1";
     public static StatusForm ShowSingleton()
     {
         if (instance == null || instance.IsDisposed)
@@ -49,6 +55,51 @@ public class StatusForm : Form
             Dock = DockStyle.Top,
             Height = 32
         };
+        pawnIoStatusLabel = new Label
+        {
+            AutoSize = false,
+            TextAlign = ContentAlignment.MiddleLeft,
+            Dock = DockStyle.Top,
+            Height = 20
+        };
+        pawnIoStateLinkLabel = new LinkLabel
+        {
+            AutoSize = true,
+            TextAlign = ContentAlignment.TopLeft,
+            Dock = DockStyle.Top,
+            MaximumSize = new Size(460, 0),
+            LinkBehavior = LinkBehavior.HoverUnderline
+        };
+        openPawnIoInstallerButton = new Button
+        {
+            Text = "Open PawnIO Installer Website",
+            AutoSize = true
+        };
+        openRepoButton = new Button
+        {
+            Text = "Open CmpInf GitHub page",
+            AutoSize = true
+        };
+        var pawnIoButtonPanel = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Bottom,
+            FlowDirection = FlowDirection.LeftToRight,
+            Height = 30,
+            Padding = new Padding(0),
+            Margin = new Padding(0)
+        };
+        pawnIoButtonPanel.Controls.Add(openPawnIoInstallerButton);
+        pawnIoButtonPanel.Controls.Add(openRepoButton);
+        var pawnIoPanel = new Panel
+        {
+            Dock = DockStyle.Top,
+            Padding = new Padding(8, 4, 8, 4),
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        pawnIoPanel.Controls.Add(pawnIoButtonPanel);
+        pawnIoPanel.Controls.Add(pawnIoStateLinkLabel);
+        pawnIoPanel.Controls.Add(pawnIoStatusLabel);
         debugCheckBox = new CheckBox
         {
             Text = "Enable Debug Logs",
@@ -65,12 +116,62 @@ public class StatusForm : Form
         };
         this.Controls.Add(logListBox);
         this.Controls.Add(debugCheckBox);
+        this.Controls.Add(pawnIoPanel);
         this.Controls.Add(label);
+        openPawnIoInstallerButton.Click += (s, e) =>
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "https://pawnio.eu/",
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Opening PawnIO installer website failed: {ex.Message}");
+            }
+        };
+        openRepoButton.Click += (s, e) =>
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "https://github.com/TBSniller/cmpinf",
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Opening repository link failed: {ex.Message}");
+            }
+        };
+        pawnIoStateLinkLabel.LinkClicked += (s, e) =>
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = PawnIoIssueUrl,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Opening PawnIO link failed: {ex.Message}");
+            }
+        };
+        UpdatePawnIoStatus();
         this.VisibleChanged += (s, e) =>
         {
             if (this.Visible)
             {
                 Log.OnLog += AddLog;
+                // Re-emit driver status once the log window is visible so the user can see which kernel driver is active.
+                HardwareReader.LogPawnIoStatus();
+                UpdatePawnIoStatus();
             }
             else
             {
@@ -97,5 +198,33 @@ public class StatusForm : Form
         if (level == "DEBUG" && !debugCheckBox.Checked) return;
         logListBox.Items.Add(msg);
         logListBox.TopIndex = logListBox.Items.Count - 1;
+    }
+
+    private void UpdatePawnIoStatus()
+    {
+        bool installed = HardwareReader.IsPawnIoInstalled();
+        var version = HardwareReader.GetPawnIoVersion();
+        pawnIoStatusLabel.Text = installed
+            ? $"PawnIO status: installed (version {version})."
+            : "PawnIO status: not installed. Restart CmpInf after installation.";
+        const string linkText = "[PawnIO.Setup GitHub Issue #1]";
+        const string missingText = "PawnlO is required for some motherboard or CPU sensors, that are not handled by LibreHardwareMonitorLib alone. Be aware that PawnIO can have an influence on cheat detection software like FaceIT: " + linkText;
+        pawnIoStateLinkLabel.Text = installed
+            ? "PawnIO is installed; motherboard and CPU sensors should be available."
+            : missingText;
+        pawnIoStateLinkLabel.Links.Clear();
+        if (!installed)
+        {
+            int start = missingText.IndexOf(linkText, StringComparison.Ordinal);
+            if (start >= 0)
+            {
+                pawnIoStateLinkLabel.Links.Add(start, linkText.Length, PawnIoIssueUrl);
+                pawnIoStateLinkLabel.LinkArea = new LinkArea(start, linkText.Length);
+            }
+        }
+        else
+        {
+            pawnIoStateLinkLabel.LinkArea = new LinkArea(0, 0);
+        }
     }
 }


### PR DESCRIPTION
- LHM got updated to [0.9.5](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/tag/v0.9.5): 
  - They have removed WinRing0 (AntiVirus trigger) and switched to PawnIO: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1857
  - PawnIO needs seperate installation for CPU/motherboard sensors: https://pawnio.eu/
  - CmpInf will encourage for PawnIO installation and gives information if it's not installed
- .NET runtime upgrade to .NET10 
- Added some AI context for better results