### PR TITLE
Make storage sensor polling optional via IsStorageEnabled setting

### DIFF
--- a/HardwareReader.cs
+++ b/HardwareReader.cs
@@ -51,7 +51,7 @@ public class HardwareReader
     {
     }
 
-    public HardwareReader(HardwareAccessMode accessMode)
+    public HardwareReader(HardwareAccessMode accessMode, bool isStorageEnabled = false)
     {
         _accessMode = accessMode;
         _computer = new Computer
@@ -62,7 +62,7 @@ public class HardwareReader
             IsMemoryEnabled = true,
             IsControllerEnabled = accessMode == HardwareAccessMode.Full,
             IsNetworkEnabled = true,
-            IsStorageEnabled = true
+            IsStorageEnabled = isStorageEnabled
         };
 
         if (_accessMode == HardwareAccessMode.SafeUserMode)

--- a/Program.cs
+++ b/Program.cs
@@ -128,7 +128,7 @@ class Program
         var desiredMode = DetermineHardwareAccessMode(settings);
         if (!File.Exists(sensorsPath))
         {
-            GenerateAvailableSensors(sensorsPath, desiredMode, "Initial sensor scan");
+            GenerateAvailableSensors(sensorsPath, desiredMode, "Initial sensor scan", settings.IsStorageEnabled);
         }
 
         // Admin rights check
@@ -165,7 +165,7 @@ class Program
         settingsMenu.DropDownItems.Add("Regenerate available-sensors.json (after installing PawnIO)", null, (s, e) => {
             try {
                 var desiredMode = DetermineHardwareAccessMode(settings);
-                GenerateAvailableSensors(SensorsFile, desiredMode, "Manual sensor regeneration");
+                GenerateAvailableSensors(SensorsFile, desiredMode, "Manual sensor regeneration", settings.IsStorageEnabled);
                 Log.Info("available-sensors.json regenerated.");
             } catch (Exception ex) { Log.Warn($"Regenerate sensors failed: {ex.Message}"); }
         });
@@ -174,7 +174,7 @@ class Program
                 if (!File.Exists(SensorsFile))
                 {
                     var desiredMode = DetermineHardwareAccessMode(settings);
-                    GenerateAvailableSensors(SensorsFile, desiredMode, "Opening available-sensors.json");
+                    GenerateAvailableSensors(SensorsFile, desiredMode, "Opening available-sensors.json", settings.IsStorageEnabled);
                 }
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                 {
@@ -312,7 +312,7 @@ class Program
             return;
         }
         var desiredMode = DetermineHardwareAccessMode(settings);
-        var hardwareReader = new HardwareReader(desiredMode);
+        var hardwareReader = new HardwareReader(desiredMode, settings.IsStorageEnabled);
         CheckConfiguredSensorsExist(hardwareReader, settings);
         if (settings.Pages.Count == 0 || settings.Pages.All(p => p.Sensors.Count == 0))
         {
@@ -540,9 +540,9 @@ class Program
         return mode;
     }
 
-    static void GenerateAvailableSensors(string path, HardwareAccessMode desiredMode, string context)
+    static void GenerateAvailableSensors(string path, HardwareAccessMode desiredMode, string context, bool isStorageEnabled = false)
     {
-        var reader = new HardwareReader(desiredMode);
+        var reader = new HardwareReader(desiredMode, isStorageEnabled);
         reader.ExportSensors(path);
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Global:
 - `GameSenseHeartbeatIntervalMs`: Set the interval in milliseconds how often a heartbeat will be sent to the GameSense GG software, when no sensor was updated
 - `RunAsAdmin`: Set to `true` if you want to run the application as administrator
 - `ShowCapsLockIndicator`: Set to `true` if you want the Caps Lock marker to display on the OLED.
+- `IsStorageEnabled`: Set to `true` to enable storage/disk sensor polling. Defaults to `false` because continuous polling can cause clicking noises on mechanical hard drives.
 - `CapsLockIndicatorTextLine1`: Text that is prepended to line 1 when Caps Lock is active (default `⇪ `). Stick to BMP-friendly glyphs so surrogate-pair emoji do not break the display.
 - `CapsLockIndicatorTextLine2`: Text that is prepended to line 2 when Caps Lock is active (default two spaces) to keep the second line aligned when the first line receives the marker.
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -19,6 +19,8 @@ public class Settings
     public HardwareAccessMode HardwareAccessMode { get; set; } = HardwareAccessMode.Full;
     [JsonProperty("ShowCapsLockIndicator")]
     public bool ShowCapsLockIndicator { get; set; } = true;
+    [JsonProperty("IsStorageEnabled")]
+    public bool IsStorageEnabled { get; set; } = false;
     [JsonProperty("CapsLockIndicatorTextLine1")]
     public string CapsLockIndicatorTextLine1 { get; set; } = "⇪ ";
     [JsonProperty("CapsLockIndicatorTextLine2")]
@@ -34,6 +36,7 @@ public class Settings
             GameSenseHeartbeatIntervalMs = 10000,
             HardwareAccessMode = HardwareAccessMode.Full,
             ShowCapsLockIndicator = true,
+            IsStorageEnabled = false,
             CapsLockIndicatorTextLine1 = "⇪ ",
             CapsLockIndicatorTextLine2 = "  ",
             Pages = new List<OledPage>


### PR DESCRIPTION
Add IsStorageEnabled setting (defaults to false) to prevent continuous disk polling that can cause clicking noises on mechanical hard drives. The setting is threaded through HardwareReader constructor and GenerateAvailableSensors calls. Updated README with documentation.